### PR TITLE
Update to gitea/gitea:1.20

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   gitea:
-    image: gitea/gitea:1.19
+    image: gitea/gitea:1.20
     restart: always
     environment:
       USER_UID: 1000


### PR DESCRIPTION
- https://mstdn.aoirint.com/@aoirint/110743707004266362

Gitea 1.19のインスタンスを1.20に更新すると、以下のようなエラーが出て起動しません。

```
>...g/config_provider.go:327:deprecatedSettingFatal() [F] Deprecated fallback `[server]` `LFS_CONTENT_PATH` present. Use `[lfs]` `PATH` instead. This fallback will be/has been removed in v1.19.0
> Received signal 15; terminating.
```

- https://github.com/go-gitea/gitea/issues/25995

`/data/gitea/conf/app.ini`に破壊的変更があり、以下のように書き換える必要があります。

変更前

```ini
[server]
LFS_CONTENT_PATH = /data/git/lfs
```

変更後

```ini
[lfs]
PATH = /data/git/lfs
```

LFS関連の設定はほかに、`LFS_START_SERVER`、`LFS_JWT_SECRET`などがありますが、`[lfs]`に移動されたのは`LFS_CONTENT_PATH `だけのようです。

このエラーは、以下の`deprecatedSettingFatal(rootCfg, "server", "LFS_CONTENT_PATH", "lfs", "PATH", "v1.19.0")`で発生しており、

- https://github.com/go-gitea/gitea/blob/e627f161c2ff75d3bb66b494ce8d9d2b77e6b7ec/modules/setting/lfs.go#L37

以下のPRで、起動時にLFS storageを正常に初期化するために、`log.Fatal`を呼び出す`deprecatedSettingFatal`とともに実装されました。

- (main branch) https://github.com/go-gitea/gitea/pull/23911
    - https://github.com/go-gitea/gitea/pull/23911#discussion_r1227568979
    - https://github.com/go-gitea/gitea/pull/23911#issuecomment-1590497161
- (backport to v1.20) https://github.com/go-gitea/gitea/pull/25244
